### PR TITLE
Enhance: Changed `ErrorController` to a generic class

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -67,10 +67,20 @@ module.exports = {
     },
     {
       files: [
+        'src/handlers/ErrorController.ts',
+        'src/handlers/interfaces/IErrorControllerOption.ts',
+      ],
+      rules: {
+        '@typescript-eslint/no-explicit-any': ['off'],
+      },
+    },
+    {
+      files: [
         'src/handlers/ErrorHandler.ts',
         'src/handlers/ApiErrorHandler.ts',
         'src/handlers/SchemaErrorHandler.ts',
         'src/handlers/DefaultErrorHandler.ts',
+        'src/handlers/HTTPErrorHandler.ts',
       ],
       rules: {
         '@typescript-eslint/no-floating-promises': ['off'],

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   },
   "dependencies": {
     "@maeum/tools": "^1.3.0",
+    "accept-language": "^3.0.18",
     "error-stack-parser": "^2.1.4",
     "fast-json-stringify": "^5.6.2",
     "http-status-codes": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@maeum/tools':
     specifier: ^1.3.0
     version: 1.3.0(ajv@8.12.0)(fastify@4.23.2)
+  accept-language:
+    specifier: ^3.0.18
+    version: 3.0.18
   error-stack-parser:
     specifier: ^2.1.4
     version: 2.1.4
@@ -1475,6 +1478,13 @@ packages:
   /abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  /accept-language@3.0.18:
+    resolution: {integrity: sha512-sUofgqBPzgfcF20sPoBYGQ1IhQLt2LSkxTnlQSuLF3n5gPEqd5AimbvOvHEi0T1kLMiGVqPWzI5a9OteBRth3A==}
+    dependencies:
+      bcp47: 1.1.2
+      stable: 0.1.8
+    dev: false
+
   /acorn-jsx@5.3.2(acorn@8.10.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1789,6 +1799,11 @@ packages:
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  /bcp47@1.1.2:
+    resolution: {integrity: sha512-JnkkL4GUpOvvanH9AZPX38CxhiLsXMBicBY2IAtqiVN8YulGDQybUydWA4W6yAMtw6iShtw+8HEF6cfrTHU+UQ==}
+    engines: {node: '>=0.10'}
+    dev: false
 
   /big-integer@1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
@@ -5388,6 +5403,11 @@ packages:
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: true
+
+  /stable@0.1.8:
+    resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
+    deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
+    dev: false
 
   /stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}

--- a/src/handlers/DefaultErrorHandler.ts
+++ b/src/handlers/DefaultErrorHandler.ts
@@ -1,41 +1,18 @@
 import ErrorHandler from '#/handlers/ErrorHandler';
-import getSourceLocation from '#/modules/getSourceLocation';
-import { EncryptContiner, noop, safeStringify } from '@maeum/tools';
-import type { ErrorObject } from 'ajv';
-import type { FastifyReply, FastifyRequest } from 'fastify';
-import httpStatusCodes from 'http-status-codes';
-import { isError } from 'my-easy-fp';
+import { noop, safeStringify } from '@maeum/tools';
 
-export default class DefaultErrorHandler extends ErrorHandler {
-  public override isSelected(err: Error & { validation?: ErrorObject[] }): boolean {
-    return isError(err) != null && err.validation != null;
+export default class DefaultErrorHandler extends ErrorHandler<Error> {
+  public override isSelected(): boolean {
+    return true;
   }
 
-  protected preHook(
-    _err: Error & { validation?: ErrorObject[] },
-    _req: FastifyRequest,
-    reply: FastifyReply,
-  ): void {
-    reply.status(httpStatusCodes.INTERNAL_SERVER_ERROR);
-    reply.header('Content-Type', 'application/json');
-  }
+  protected preHook = noop;
 
   protected postHook = noop;
 
-  protected serializor(
-    err: Error & { validation?: ErrorObject[] },
-    req: FastifyRequest,
-    _reply: FastifyReply,
-  ): { code: string; message?: string } {
-    const code = getSourceLocation(err);
-    const message = this.getMessage(req, { message: err.message });
-    const encrypted =
-      this.option.encryption && EncryptContiner.isBootstrap
-        ? EncryptContiner.it.encrypt(code)
-        : code;
+  protected serializor = noop;
 
-    return { code: encrypted, message };
-  }
+  public finalize = noop;
 
   public stringify(data: unknown): string {
     return safeStringify(data);

--- a/src/handlers/ErrorController.ts
+++ b/src/handlers/ErrorController.ts
@@ -1,12 +1,16 @@
 import ApiErrorHandler from '#/handlers/ApiErrorHandler';
 import DefaultErrorHandler from '#/handlers/DefaultErrorHandler';
 import type ErrorHandler from '#/handlers/ErrorHandler';
+import HTTPErrorHandler from '#/handlers/HTTPErrorHandler';
 import SchemaErrorHandler from '#/handlers/SchemaErrorHandler';
 import type IErrorControllerOption from '#/handlers/interfaces/IErrorControllerOption';
+import type THTTPErrorHandlerParameters from '#/handlers/interfaces/THTTPErrorHandlerParameters';
 import type TTranslateFunction from '#/handlers/interfaces/TTranslateFunction';
+import getLanguageFromRequestHeader from '#/modules/getLanguageFromRequestHeader';
 import type { ErrorObject } from 'ajv';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { atOrUndefined } from 'my-easy-fp';
+import { isPromise } from 'util/types';
 
 export default class ErrorController {
   static #it: ErrorController;
@@ -26,45 +30,141 @@ export default class ErrorController {
       args?.fallbackMessage ?? 'internal server error, please retry again later';
     const encryption = args?.encryption ?? true;
     const translate = args?.translate ?? (() => undefined);
+    const defaultLanguage = args?.defaultLanguage ?? 'en';
+    const getLanguage =
+      args?.getLanguage ??
+      ((languageArgs: THTTPErrorHandlerParameters) =>
+        getLanguageFromRequestHeader(
+          defaultLanguage,
+          languageArgs.req.headers['accept-languages'],
+        ));
 
     ErrorController.#it = new ErrorController(translate);
 
     if (args?.handlers == null || args?.handlers.length === 0) {
-      ErrorController.#it.add(new SchemaErrorHandler({ encryption, translate, fallbackMessage }));
-      ErrorController.#it.add(new ApiErrorHandler({ encryption, translate, fallbackMessage }));
+      ErrorController.#it.add(
+        new SchemaErrorHandler({
+          encryption,
+          translate,
+          fallbackMessage,
+          getLanguage,
+        }),
+      );
+      ErrorController.#it.add(
+        new ApiErrorHandler({ encryption, translate, fallbackMessage, getLanguage }),
+      );
+      ErrorController.#it.add(
+        new HTTPErrorHandler({ encryption, translate, fallbackMessage, getLanguage }),
+      );
+
       ErrorController.#it.#fallback =
-        args?.fallback ?? new DefaultErrorHandler({ encryption, translate, fallbackMessage });
+        args?.fallback ??
+        new DefaultErrorHandler({
+          encryption,
+          translate,
+          fallbackMessage,
+          getLanguage: () => 'en',
+        });
     } else {
       if (args?.includeDefaultHandler ?? false) {
-        ErrorController.#it.add(new SchemaErrorHandler({ encryption, translate, fallbackMessage }));
-        ErrorController.#it.add(new ApiErrorHandler({ encryption, translate, fallbackMessage }));
+        ErrorController.#it.add(
+          new SchemaErrorHandler({
+            encryption,
+            translate,
+            fallbackMessage,
+            getLanguage,
+          }),
+        );
+        ErrorController.#it.add(
+          new ApiErrorHandler({ encryption, translate, fallbackMessage, getLanguage }),
+        );
+        ErrorController.#it.add(
+          new HTTPErrorHandler({ encryption, translate, fallbackMessage, getLanguage }),
+        );
       }
 
       ErrorController.#it.add(...args.handlers);
       ErrorController.#it.#fallback =
-        args?.fallback ?? new DefaultErrorHandler({ encryption, translate, fallbackMessage });
+        args?.fallback ??
+        new DefaultErrorHandler({
+          encryption,
+          translate,
+          fallbackMessage,
+          getLanguage: () => 'en',
+        });
     }
 
     ErrorController.#isBootstrap = true;
   }
 
-  static get handler() {
+  static get fastifyHandler() {
     if (!ErrorController.#isBootstrap) {
       throw new Error('initialize with the `bootstrap` function before use');
     }
 
     return function globalErrorHandler(
-      err: Error & { validation?: ErrorObject[] },
+      err: Error & { validation?: ErrorObject[]; statusCode?: number },
       req: FastifyRequest,
       reply: FastifyReply,
     ) {
-      ErrorController.#it.send(err, req, reply);
+      ErrorController.#it.finalize({
+        $kind: 'fastify',
+        err,
+        req,
+        reply,
+      } satisfies THTTPErrorHandlerParameters);
     };
   }
 
-  #handlers: ErrorHandler[];
+  static wrap<T = void>(handler: () => Promise<T>): () => Promise<T>;
+  static wrap<T = void>(handler: () => T): () => T;
+  static wrap<T = void>(handler: () => T | Promise<T>): (() => T) | (() => Promise<T>) {
+    if (!(handler instanceof Function)) {
+      throw new Error('handler only permit function');
+    }
 
-  #fallback: ErrorHandler;
+    if (handler.constructor.name === 'AsyncFunction') {
+      const wrappedAsyncHandler = async () => {
+        try {
+          const handled = await handler();
+          return handled;
+        } catch (err) {
+          ErrorController.#it.finalize(err);
+          throw err;
+        }
+      };
+
+      return wrappedAsyncHandler;
+    }
+
+    const wrappedSyncHandler = (() => {
+      try {
+        const handled = handler();
+        return handled;
+      } catch (err) {
+        ErrorController.#it.finalize(err);
+        throw err;
+      }
+    }) as () => T;
+
+    return wrappedSyncHandler;
+  }
+
+  static async handle(handler: () => void | Promise<void>) {
+    try {
+      const handled = handler();
+
+      if (isPromise(handled)) {
+        await handled;
+      }
+    } catch (err) {
+      ErrorController.#it.finalize(err);
+    }
+  }
+
+  #handlers: ErrorHandler<any>[];
+
+  #fallback: ErrorHandler<any>;
 
   #translate: TTranslateFunction;
 
@@ -74,11 +174,12 @@ export default class ErrorController {
       encryption: true,
       translate,
       fallbackMessage: 'internal server error, please retry again later',
+      getLanguage: () => 'en',
     });
     this.#translate = translate;
   }
 
-  get handlers(): ErrorHandler[] {
+  get handlers(): ErrorHandler<unknown>[] {
     return this.#handlers;
   }
 
@@ -86,7 +187,7 @@ export default class ErrorController {
     return this.#translate;
   }
 
-  add(...handlers: ErrorHandler[]) {
+  add(...handlers: ErrorHandler<any>[]) {
     const names = handlers.map((handler) => handler.constructor.name);
     const next = this.#handlers.filter((handler) => !names.includes(handler.constructor.name));
     next.push(...handlers);
@@ -94,18 +195,18 @@ export default class ErrorController {
     this.#handlers = next;
   }
 
-  remove(...handlers: ErrorHandler[]) {
+  remove(...handlers: ErrorHandler<any>[]) {
     const names = handlers.map((handler) => handler.constructor.name);
     const next = this.#handlers.filter((handler) => !names.includes(handler.constructor.name));
 
     this.#handlers = next;
   }
 
-  send(err: Error & { validation?: ErrorObject[] }, req: FastifyRequest, reply: FastifyReply) {
-    const handlers = this.#handlers.filter((handler) => handler.isSelected(err, req, reply));
+  finalize(args: any) {
+    const handlers = this.#handlers.filter((handler) => handler.isSelected(args));
     const handler = atOrUndefined(handlers, 0);
     const selected = handler ?? this.#fallback;
 
-    selected.handler(err, req, reply);
+    selected.handler(args);
   }
 }

--- a/src/handlers/HTTPErrorHandler.ts
+++ b/src/handlers/HTTPErrorHandler.ts
@@ -1,0 +1,111 @@
+import ErrorHandler from '#/handlers/ErrorHandler';
+import type IErrorHandlerOption from '#/handlers/interfaces/IErrorHandlerOption';
+import type THTTPErrorHandlerParameters from '#/handlers/interfaces/THTTPErrorHandlerParameters';
+import getSourceLocation from '#/modules/getSourceLocation';
+import { EncryptContiner, noop, safeStringify } from '@maeum/tools';
+import httpStatusCodes from 'http-status-codes';
+import { isError } from 'my-easy-fp';
+
+export default class HTTPErrorHandler extends ErrorHandler<THTTPErrorHandlerParameters> {
+  #option: IErrorHandlerOption<THTTPErrorHandlerParameters>;
+
+  constructor(option: IErrorHandlerOption<THTTPErrorHandlerParameters>) {
+    super(option);
+
+    this.#option = option;
+  }
+
+  public isSelected(args: THTTPErrorHandlerParameters): boolean {
+    if (!('$kind' in args) || args.$kind !== 'fastify') {
+      return false;
+    }
+
+    if (isError(args.err) == null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public stringify(data: unknown): string {
+    return safeStringify(data);
+  }
+
+  get option() {
+    return this.#option;
+  }
+
+  /**
+   * 모든 오류를 일관성 있게 error handler에서 처리하는 경우, route에서 설정한 것과 다른 형태로
+   * replay 데이터를 응답하게 되는 경우가 있다. 500오류가 발생하면 그런 상황이 발생하기 쉽다. 그래서
+   * 이런 경우에 send나 serialize에 강제로 데이터를 보낼 수 있는데 이 때 header의 content-type
+   * 데이터 등을 변경해야 할 수 있다. 이 때 hook을 사용한다
+   *
+   * If all errors are handled consistently by the error handler, you may end up
+   * responding with replay data in a different format than you set in the route.
+   * This is most likely to happen with 500 errors, so you may want to force send
+   * or serialize to send the data, which may require changing the content-type
+   * data in the header, etc. This is where hooks come in
+   */
+
+  protected preHook(args: THTTPErrorHandlerParameters): void {
+    if ('setRequestError' in args.req && typeof args.req.setRequestError === 'function') {
+      args.req.setRequestError(args.err);
+    }
+
+    args.reply.status(args.err.statusCode ?? httpStatusCodes.INTERNAL_SERVER_ERROR);
+    args.reply.header('Content-Type', 'application/json');
+  }
+
+  protected postHook = noop;
+
+  protected serializor(args: THTTPErrorHandlerParameters): { code: string; message?: string } {
+    const code = getSourceLocation(args.err);
+    const message = this.getMessage(args, { message: args.err.message });
+    const encrypted =
+      this.option.encryption && EncryptContiner.isBootstrap
+        ? EncryptContiner.it.encrypt(code)
+        : code;
+
+    return { code: encrypted, message };
+  }
+
+  finalize(args: THTTPErrorHandlerParameters, payload: string): void {
+    setImmediate(() => {
+      args.reply.send(payload);
+    });
+  }
+
+  getMessage(args: THTTPErrorHandlerParameters, i18n: { translate?: unknown; message?: string }) {
+    try {
+      if (i18n.translate != null) {
+        const language = this.#option.getLanguage(args);
+        const message = this.#option.translate(language, i18n.translate);
+
+        if (message != null) {
+          return message;
+        }
+      }
+
+      if (i18n.message != null) {
+        return i18n.message;
+      }
+
+      if (typeof this.#option.fallbackMessage === 'string') {
+        return this.#option.fallbackMessage;
+      }
+
+      return this.#option.fallbackMessage(args);
+    } catch {
+      return undefined;
+    }
+  }
+
+  handler(args: THTTPErrorHandlerParameters) {
+    this.preHook(args);
+    const payload = this.serializor(args);
+    const stringified = this.stringify(payload);
+    this.finalize(args, stringified);
+    this.postHook(args);
+  }
+}

--- a/src/handlers/SchemaErrorHandler.ts
+++ b/src/handlers/SchemaErrorHandler.ts
@@ -1,47 +1,55 @@
-import ErrorHandler from '#/handlers/ErrorHandler';
+import HTTPErrorHandler from '#/handlers/HTTPErrorHandler';
+import type THTTPErrorHandlerParameters from '#/handlers/interfaces/THTTPErrorHandlerParameters';
 import getSourceLocation from '#/modules/getSourceLocation';
 import type ISchemaErrorReply from '#/modules/interfaces/ISchemaErrorReply';
 import { EncryptContiner, getValidationErrorSummary, noop, safeStringify } from '@maeum/tools';
-import type { ErrorObject } from 'ajv';
-import type { FastifyReply, FastifyRequest } from 'fastify';
 import httpStatusCodes from 'http-status-codes';
 import { isError } from 'my-easy-fp';
 
-export default class SchemaErrorHandler extends ErrorHandler {
-  public override isSelected(err: Error & { validation?: ErrorObject[] }): boolean {
-    return isError(err) != null && err.validation != null;
+export default class SchemaErrorHandler extends HTTPErrorHandler {
+  public override isSelected(args: THTTPErrorHandlerParameters): boolean {
+    if (!('$kind' in args) || args.$kind !== 'fastify') {
+      return false;
+    }
+
+    if (isError(args.err) == null) {
+      return false;
+    }
+
+    if (args.err.validation == null) {
+      return false;
+    }
+
+    return true;
   }
 
-  protected preHook(
-    err: Error & { statusCode?: number; validation?: ErrorObject[] },
-    _req: FastifyRequest,
-    reply: FastifyReply,
-  ): void {
-    reply.status(err.statusCode ?? httpStatusCodes.BAD_REQUEST);
-    reply.header('Content-Type', 'application/json');
+  protected preHook(args: THTTPErrorHandlerParameters): void {
+    super.preHook(args);
+
+    args.reply.status(args.err.statusCode ?? httpStatusCodes.BAD_REQUEST);
   }
 
   protected postHook = noop;
 
-  protected serializor(
-    err: Error & { validation?: ErrorObject[] },
-    req: FastifyRequest,
-    _reply: FastifyReply,
-  ): { code: string; message?: string; validation?: ISchemaErrorReply['validation'] } {
-    if (isError(err) != null && err.validation != null) {
-      const code = getSourceLocation(err);
-      const message = this.getMessage(req, { message: err.message });
+  protected serializor(args: THTTPErrorHandlerParameters): {
+    code: string;
+    message?: string;
+    validation?: ISchemaErrorReply['validation'];
+  } {
+    if (isError(args.err) != null && args.err.validation != null) {
+      const code = getSourceLocation(args.err);
+      const message = this.getMessage(args, { message: args.err.message });
       const encrypted =
         this.option.encryption && EncryptContiner.isBootstrap
           ? EncryptContiner.it.encrypt(code)
           : code;
-      const validation = getValidationErrorSummary(err.validation);
+      const validation = getValidationErrorSummary(args.err.validation);
 
       return { code: encrypted, validation, message };
     }
 
-    const code = getSourceLocation(err);
-    const message = this.getMessage(req, { message: err.message });
+    const code = getSourceLocation(args.err);
+    const message = this.getMessage(args, { message: args.err.message });
     const encrypted =
       this.option.encryption && EncryptContiner.isBootstrap
         ? EncryptContiner.it.encrypt(code)

--- a/src/handlers/interfaces/IErrorControllerOption.ts
+++ b/src/handlers/interfaces/IErrorControllerOption.ts
@@ -1,12 +1,14 @@
 import type ErrorHandler from '#/handlers/ErrorHandler';
+import type TGetLanguageFunction from '#/handlers/interfaces/TGetLanguageFunction';
 import type TTranslateFunction from '#/handlers/interfaces/TTranslateFunction';
-import type { FastifyRequest } from 'fastify';
 
 export default interface IErrorControllerOption {
   translate?: TTranslateFunction;
+  getLanguage?: TGetLanguageFunction<unknown>;
+  defaultLanguage?: string;
+  fallbackMessage?: string | ((args: unknown) => string);
   encryption?: boolean;
-  fallback?: ErrorHandler;
+  fallback?: ErrorHandler<any>;
   includeDefaultHandler?: boolean;
-  handlers?: ErrorHandler[];
-  fallbackMessage?: string | ((req: FastifyRequest) => string);
+  handlers?: ErrorHandler<any>[];
 }

--- a/src/handlers/interfaces/IErrorHandlerOption.ts
+++ b/src/handlers/interfaces/IErrorHandlerOption.ts
@@ -1,8 +1,9 @@
+import type TGetLanguageFunction from '#/handlers/interfaces/TGetLanguageFunction';
 import type TTranslateFunction from '#/handlers/interfaces/TTranslateFunction';
-import type { FastifyRequest } from 'fastify';
 
-export default interface IErrorHandlerOption {
+export default interface IErrorHandlerOption<T> {
   encryption: boolean;
-  fallbackMessage: string | ((req: FastifyRequest) => string);
+  fallbackMessage: string | ((args: T) => string);
+  getLanguage: TGetLanguageFunction<T>;
   translate: TTranslateFunction;
 }

--- a/src/handlers/interfaces/TGetLanguageFunction.ts
+++ b/src/handlers/interfaces/TGetLanguageFunction.ts
@@ -1,0 +1,3 @@
+type TGetLanguageFunction<T> = (args: T) => string;
+
+export default TGetLanguageFunction;

--- a/src/handlers/interfaces/THTTPErrorHandlerParameters.ts
+++ b/src/handlers/interfaces/THTTPErrorHandlerParameters.ts
@@ -1,0 +1,11 @@
+import type { ErrorObject } from 'ajv';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+type THTTPErrorHandlerParameters = {
+  $kind: 'fastify';
+  err: Error & { validation?: ErrorObject[]; statusCode?: number };
+  req: FastifyRequest;
+  reply: FastifyReply;
+};
+
+export default THTTPErrorHandlerParameters;

--- a/src/handlers/interfaces/TTranslateFunction.ts
+++ b/src/handlers/interfaces/TTranslateFunction.ts
@@ -1,5 +1,3 @@
-import type { FastifyRequest } from 'fastify';
-
-type TTranslateFunction = (req: FastifyRequest, option: unknown) => string | undefined;
+type TTranslateFunction = (language: string, option: unknown) => string | undefined;
 
 export default TTranslateFunction;

--- a/src/modules/getLanguageFromRequestHeader.ts
+++ b/src/modules/getLanguageFromRequestHeader.ts
@@ -1,0 +1,9 @@
+import acceptLanguage from 'accept-language';
+
+export default function getLanguageFromRequestHeader(
+  defaultLanguage: string,
+  languages?: string | string[],
+): string {
+  const language = Array.isArray(languages) ? languages.join(', ') : languages;
+  return acceptLanguage.get(language) ?? defaultLanguage;
+}


### PR DESCRIPTION
- `ErrorController` can now handle general errors, not just HTTP errors.
  - You can now use `ErrorController` to handle errors in a variety of cases, including when running a cron job and when receiving MQ messages